### PR TITLE
Remove override of main pkg path

### DIFF
--- a/pydust/buildzig.py
+++ b/pydust/buildzig.py
@@ -90,7 +90,6 @@ def generate_build_zig(build_zig_file):
                     _ = pydust.addPythonModule(.{{
                         .name = "{ext_module.name}",
                         .root_source_file = .{{ .path = "{ext_module.root}" }},
-                        .main_pkg_path = .{{ .path = "{conf.root}" }},
                         .limited_api = {str(ext_module.limited_api).lower()},
                         .target = target,
                         .optimize = optimize,

--- a/pydust/config.py
+++ b/pydust/config.py
@@ -44,7 +44,6 @@ class ExtModule(BaseModel):
 class ToolPydust(BaseModel):
     """Model for tool.pydust section of a pyproject.toml."""
 
-    root: str = "src/"
     build_zig: str = "build.zig"
 
     # When true, python module definitions are configured by the user in their own build.zig file.


### PR DESCRIPTION
This default didn't really make much sense. And it's not clear there's a use-case to override at the moment.