### PR TITLE
Only keep latest minor version of docs

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -65,8 +65,11 @@ jobs:
         run: |
           git config --global user.name Docs Deploy
           git config --global user.email docs@dummy.bot.com
+      - name: Get Version
+        id: get_version
+        uses: battila7/get-version-action@v2
       - name: MKDocs Build
-        run: poetry run mike deploy ${{  github.ref_name }} latest --push --update-aliases
+        run: poetry run mike deploy ${{ steps.get_version.outputs.major }}.${{ steps.get_version.outputs.minor }} latest --push --update-aliases
 
       - name: Publish package distributions to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1


### PR DESCRIPTION
There's far too many versions of docs otherwise. Since gh-pages is in git, we can always access old patch versions anyway.

Fixes #73 