### PR TITLE
Fix ref counts for trampolined structs and tuples

### DIFF
--- a/example/result_types.zig
+++ b/example/result_types.zig
@@ -65,6 +65,12 @@ pub fn zigf64() f64 {
     return 2.71 * std.math.pow(f64, 10, 39);
 }
 
+const TupleResult = struct { py.PyObject, u64 };
+
+pub fn zigtuple() !TupleResult {
+    return .{ py.object(try py.PyString.create("hello")), 128 };
+}
+
 const StructResult = struct { foo: u64, bar: bool };
 
 pub fn zigstruct() StructResult {

--- a/pydust/src/functions.zig
+++ b/pydust/src/functions.zig
@@ -176,7 +176,6 @@ pub fn wrap(comptime func: anytype, comptime sig: Signature, comptime flags: c_i
             } else {
                 var callArgs = if (sig.selfParam) |_| .{self} else .{};
                 const result = @call(.always_inline, func, callArgs);
-
                 return py.createOwned(result);
             }
         }

--- a/pydust/src/functions.zig
+++ b/pydust/src/functions.zig
@@ -176,6 +176,7 @@ pub fn wrap(comptime func: anytype, comptime sig: Signature, comptime flags: c_i
             } else {
                 var callArgs = if (sig.selfParam) |_| .{self} else .{};
                 const result = @call(.always_inline, func, callArgs);
+
                 return py.createOwned(result);
             }
         }

--- a/pydust/src/types/buffer.zig
+++ b/pydust/src/types/buffer.zig
@@ -52,7 +52,7 @@ pub const PyBuffer = extern struct {
     // have if it were copied to a contiguous representation.
     len: isize,
     itemsize: isize,
-    readonly: c_int,
+    readonly: bool,
 
     // If ndim == 0, the memory location pointed to by buf is interpreted as a scalar of size itemsize.
     // In that case, both shape and strides are NULL.
@@ -89,7 +89,7 @@ pub const PyBuffer = extern struct {
             .obj = ownerObj.py,
             .len = @intCast(values.len * @sizeOf(T)),
             .itemsize = @sizeOf(T),
-            .readonly = 1,
+            .readonly = true,
             .ndim = @intCast(shape.len),
             .format = getFormat(T).ptr,
             .shape = shape.ptr,

--- a/pydust/src/types/dict.zig
+++ b/pydust/src/types/dict.zig
@@ -29,7 +29,7 @@ pub const PyDict = extern struct {
         const dict = try new();
         inline for (s.fields) |field| {
             // Recursively create the field values
-            try dict.setItem(field.name, try py.create(@field(value, field.name)));
+            try dict.setOwnedItem(field.name, try py.create(@field(value, field.name)));
         }
         return dict;
     }

--- a/pydust/src/types/tuple.zig
+++ b/pydust/src/types/tuple.zig
@@ -36,7 +36,7 @@ pub const PyTuple = extern struct {
         const tuple = try new(s.fields.len);
         inline for (s.fields, 0..) |field, i| {
             // Recursively unwrap the field value
-            try tuple.setItem(@intCast(i), try py.create(@field(values, field.name)));
+            try tuple.setOwnedItem(@intCast(i), try py.create(@field(values, field.name)));
         }
         return tuple;
     }

--- a/test/test_resulttypes.py
+++ b/test/test_resulttypes.py
@@ -12,13 +12,17 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
+import sys
+
 import pytest
 
 from example import result_types
 
 
 def test_pyobject():
-    assert result_types.pyobject() == "hello"
+    result = result_types.pyobject()
+    assert result == "hello"
+    assert sys.getrefcount(result) == 2
 
 
 def test_pystring():
@@ -71,5 +75,14 @@ def test_zigf64():
     assert result_types.zigf64() == 2.7100000000000003e39
 
 
+def test_zigtuple():
+    s, i = result_types.zigtuple()
+    assert s == "hello"
+    assert i == 128
+    assert sys.getrefcount(s) == 2
+
+
 def test_zigstruct():
-    assert result_types.zigstruct() == {"foo": 1234, "bar": True}
+    result = result_types.zigstruct()
+    assert result == {"foo": 1234, "bar": True}
+    assert sys.getrefcount(result) == 2


### PR DESCRIPTION
For container types (tuple and dict), Pydust was wrapping up existing object-like things in a PyTuple.create or PyDict.create. These methods create new references to the child objects. So we need to undo this ref counting.