### PR TITLE
Recommend locking minor version in docs

### DIFF
--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -36,9 +36,13 @@ packages = [ { include = "your-module" } ]
 
 [build-system]
 - requires = ["poetry-core"]
-+ requires = ["poetry-core", "ziggy-pydust"]
++ requires = ["poetry-core", "ziggy-pydust==0.TODO_SET_MINOR_VERSION.*"]
 build-backend = "poetry.core.masonry.api"
 ```
+
+!!! note
+
+    We recommend locking the build dependency minor version before `ziggy-pydust` is `1.0`.
 
 As well as creating the `build.py` for Poetry to invoke the Pydust build.
 

--- a/docs/guide/_4_testing.md
+++ b/docs/guide/_4_testing.md
@@ -15,6 +15,22 @@ The Zig documentation provides an [excellent introduction to writing tests](http
 --8<-- "example/pytest.zig:example"
 ```
 
+Add `ziggy-pydust` as a dev dependency:
+
+```bash
+poetry add -G dev ziggy-pydust
+```
+
+```diff title="pyproject.toml"
+[tool.poetry.group.dev.dependencies]
++ ziggy-pydust = "0.TODO_SET_MINOR_VERSION.*"
+```
+
+!!! note
+
+    Keep this version the same as build dependency version. There is currently no way to guarantee this with Poetry.
+
+
 After running `poetry run pytest` you should see your Zig tests included in your Pytest output:
 
 ``` bash linenums="0"


### PR DESCRIPTION
Also, one must have ziggy-pydust as dev dependency for tests to be picked up so updated docs.