### PR TITLE
Optionally unwrap errors

### DIFF
--- a/example/classes.zig
+++ b/example/classes.zig
@@ -25,7 +25,7 @@ pub const SomeClass = py.class(struct {
 pub const ConstructableClass = py.class(struct {
     count: u32 = 0,
 
-    pub fn __new__(args: struct { count: u32 }) !@This() {
+    pub fn __new__(args: struct { count: u32 }) @This() {
         return .{ .count = args.count };
     }
 });
@@ -67,7 +67,7 @@ pub const Dog = py.class(struct {
 pub const User = py.class(struct {
     const Self = @This();
 
-    pub fn __new__(args: struct { name: py.PyString }) !Self {
+    pub fn __new__(args: struct { name: py.PyString }) Self {
         args.name.incref();
         return .{ .name = args.name, .email = .{} };
     }
@@ -78,7 +78,7 @@ pub const User = py.class(struct {
 
         e: ?py.PyString = null,
 
-        pub fn get(prop: *const Prop) !?py.PyString {
+        pub fn get(prop: *const Prop) ?py.PyString {
             return prop.e;
         }
 
@@ -108,7 +108,7 @@ pub const Counter = py.class(struct {
 
     count: py.attribute(usize) = .{ .value = 0 },
 
-    pub fn __new__(args: struct {}) !Self {
+    pub fn __new__(args: struct {}) Self {
         _ = args;
         return .{};
     }

--- a/example/exceptions.zig
+++ b/example/exceptions.zig
@@ -19,6 +19,12 @@ pub fn raise_value_error(args: struct { message: py.PyString }) !void {
 }
 // --8<-- [end:valueerror]
 
+pub const CustomError = error{Oops};
+
+pub fn raise_custom_error() !void {
+    return CustomError.Oops;
+}
+
 comptime {
     py.rootmodule(@This());
 }

--- a/example/iterators.zig
+++ b/example/iterators.zig
@@ -22,7 +22,7 @@ pub const Range = py.class(struct {
     upper: i64,
     step: i64,
 
-    pub fn __new__(args: struct { lower: i64, upper: i64, step: i64 }) !Self {
+    pub fn __new__(args: struct { lower: i64, upper: i64, step: i64 }) Self {
         return .{ .lower = args.lower, .upper = args.upper, .step = args.step };
     }
 
@@ -40,11 +40,11 @@ pub const RangeIterator = py.class(struct {
     stop: i64,
     step: i64,
 
-    pub fn __new__(args: struct { next: i64, stop: i64, step: i64 }) !Self {
+    pub fn __new__(args: struct { next: i64, stop: i64, step: i64 }) Self {
         return .{ .next = args.next, .stop = args.stop, .step = args.step };
     }
 
-    pub fn __next__(self: *Self) !?i64 {
+    pub fn __next__(self: *Self) ?i64 {
         if (self.next >= self.stop) {
             return null;
         }

--- a/example/modules.zig
+++ b/example/modules.zig
@@ -39,7 +39,7 @@ pub fn count(self: *const Self) u32 {
     return self.count;
 }
 
-pub fn whoami(self: *const Self) !py.PyString {
+pub fn whoami(self: *const Self) py.PyString {
     return self.name;
 }
 

--- a/pydust/src/builtins.zig
+++ b/pydust/src/builtins.zig
@@ -68,7 +68,7 @@ pub fn is_none(object: anytype) bool {
 /// Get the length of the given object. Equivalent to len(obj) in Python.
 pub fn len(object: anytype) !usize {
     const length = ffi.PyObject_Length(py.object(object).py);
-    if (length < 0) return PyError.Propagate;
+    if (length < 0) return PyError.PyRaised;
     return @intCast(length);
 }
 
@@ -90,7 +90,7 @@ pub fn isinstance(object: anytype, cls: anytype) !bool {
     const pycls = py.object(cls);
 
     const result = ffi.PyObject_IsInstance(pyobj.py, pycls.py);
-    if (result < 0) return PyError.Propagate;
+    if (result < 0) return PyError.PyRaised;
     return result == 1;
 }
 
@@ -103,13 +103,13 @@ pub fn refcnt(object: anytype) isize {
 /// Compute a string representation of object - using str(o).
 pub fn str(object: anytype) !py.PyString {
     const pyobj = py.object(object);
-    return py.PyString.unchecked(.{ .py = ffi.PyObject_Str(pyobj.py) orelse return PyError.Propagate });
+    return py.PyString.unchecked(.{ .py = ffi.PyObject_Str(pyobj.py) orelse return PyError.PyRaised });
 }
 
 /// Compute a string representation of object - using repr(o).
 pub fn repr(object: anytype) !py.PyString {
     const pyobj = py.object(object);
-    return py.PyString.unchecked(.{ .py = ffi.PyObject_Repr(pyobj.py) orelse return PyError.Propagate });
+    return py.PyString.unchecked(.{ .py = ffi.PyObject_Repr(pyobj.py) orelse return PyError.PyRaised });
 }
 
 /// The equivalent of Python's super() builtin. Returns a PyObject.
@@ -124,10 +124,10 @@ pub fn super(comptime Super: type, selfInstance: anytype) !py.PyObject {
 }
 
 pub fn tuple(object: anytype) !py.PyTuple {
-    const pytuple = ffi.PySequence_Tuple(py.object(object).py) orelse return PyError.Propagate;
+    const pytuple = ffi.PySequence_Tuple(py.object(object).py) orelse return PyError.PyRaised;
     return py.PyTuple.unchecked(.{ .py = pytuple });
 }
 
 pub fn type_(object: anytype) !py.PyObject {
-    return .{ .py = ffi.Py_TYPE(py.object(object).py) orelse return PyError.Propagate };
+    return .{ .py = ffi.Py_TYPE(py.object(object).py) orelse return PyError.PyRaised };
 }

--- a/pydust/src/conversions.zig
+++ b/pydust/src/conversions.zig
@@ -22,17 +22,17 @@ pub fn object(value: anytype) py.PyObject {
 /// Zig -> Python. Return a Python representation of a Zig object.
 /// For Zig primitives, this constructs a new Python object.
 /// For PyObject-like values, this returns the value without creating a new reference.
-pub fn createOwned(value: anytype) !py.PyObject {
+pub fn createOwned(value: anytype) py.PyError!py.PyObject {
     return tramp.Trampoline(@TypeOf(value)).wrap(value);
 }
 
 /// Zig -> Python. Convert a Zig object into a Python object. Returns a new object.
-pub fn create(value: anytype) !py.PyObject {
+pub fn create(value: anytype) py.PyError!py.PyObject {
     return tramp.Trampoline(@TypeOf(value)).wrapNew(value);
 }
 
 /// Python -> Zig. Return a Zig object representing the Python object.
-pub fn as(comptime T: type, obj: anytype) !T {
+pub fn as(comptime T: type, obj: anytype) py.PyError!T {
     return tramp.Trampoline(T).unwrap(object(obj));
 }
 

--- a/pydust/src/errors.zig
+++ b/pydust/src/errors.zig
@@ -13,8 +13,8 @@
 const Allocator = @import("std").mem.Allocator;
 
 pub const PyError = error{
-    // Propagate an error raised from another Python function call.
-    // This is the equivalent of returning PyNULL and allowing the already set error info to remain.
-    Propagate,
-    Raised,
+    // PyError.PyRaised should be returned when an exception has been set but not caught in
+    // the Python interpreter. This tells Pydust to return PyNULL and allow Python to raise
+    // the exception to the end user.
+    PyRaised,
 } || Allocator.Error;

--- a/pydust/src/types/bytes.zig
+++ b/pydust/src/types/bytes.zig
@@ -22,14 +22,14 @@ pub const PyBytes = extern struct {
     pub usingnamespace PyObjectMixin("bytes", "PyBytes", @This());
 
     pub fn create(value: []const u8) !PyBytes {
-        const bytes = ffi.PyBytes_FromStringAndSize(value.ptr, @intCast(value.len)) orelse return PyError.Propagate;
+        const bytes = ffi.PyBytes_FromStringAndSize(value.ptr, @intCast(value.len)) orelse return PyError.PyRaised;
         return .{ .obj = .{ .py = bytes } };
     }
 
     /// Return the bytes representation of object obj that implements the buffer protocol.
     pub fn fromObject(obj: anytype) !PyBytes {
         const pyobj = py.object(obj);
-        const bytes = ffi.PyBytes_FromObject(pyobj.py) orelse return PyError.Propagate;
+        const bytes = ffi.PyBytes_FromObject(pyobj.py) orelse return PyError.PyRaised;
         return .{ .obj = .{ .py = bytes } };
     }
 
@@ -43,7 +43,7 @@ pub const PyBytes = extern struct {
         var buffer: [*]u8 = undefined;
         var size: i64 = 0;
         if (ffi.PyBytes_AsStringAndSize(self.obj.py, @ptrCast(&buffer), &size) < 0) {
-            return PyError.Propagate;
+            return PyError.PyRaised;
         }
         return buffer[0..@as(usize, @intCast(size)) :0];
     }

--- a/pydust/src/types/dict.zig
+++ b/pydust/src/types/dict.zig
@@ -54,13 +54,13 @@ pub const PyDict = extern struct {
 
     /// Return a new empty dictionary.
     pub fn new() !PyDict {
-        const dict = ffi.PyDict_New() orelse return PyError.Propagate;
+        const dict = ffi.PyDict_New() orelse return PyError.PyRaised;
         return PyDict.unchecked(.{ .py = dict });
     }
 
     /// Return a new dictionary that contains the same key-value pairs as p.
     pub fn copy(self: PyDict) !PyDict {
-        const dict = ffi.PyDict_Copy(self.obj.py) orelse return PyError.Propagate;
+        const dict = ffi.PyDict_Copy(self.obj.py) orelse return PyError.PyRaised;
         return PyDict.unchecked(.{ .py = dict });
     }
 
@@ -81,7 +81,7 @@ pub const PyDict = extern struct {
         defer keyObj.decref();
 
         const result = ffi.PyDict_Contains(self.obj.py, keyObj.py);
-        if (result < 0) return PyError.Propagate;
+        if (result < 0) return PyError.PyRaised;
         return result == 1;
     }
 
@@ -104,7 +104,7 @@ pub const PyDict = extern struct {
         defer valueObj.decref();
 
         const result = ffi.PyDict_SetItem(self.obj.py, keyObj.py, valueObj.py);
-        if (result < 0) return PyError.Propagate;
+        if (result < 0) return PyError.PyRaised;
     }
 
     /// Remove the entry in dictionary p with key key.
@@ -113,7 +113,7 @@ pub const PyDict = extern struct {
         defer keyObj.decref();
 
         if (ffi.PyDict_DelItem(self.obj.py, keyObj.py) < 0) {
-            return PyError.Propagate;
+            return PyError.PyRaised;
         }
     }
 
@@ -132,7 +132,7 @@ pub const PyDict = extern struct {
             return null;
         }
 
-        return PyError.Propagate;
+        return PyError.PyRaised;
     }
 
     pub fn itemsIterator(self: PyDict) ItemIterator {

--- a/pydust/src/types/error.zig
+++ b/pydust/src/types/error.zig
@@ -95,7 +95,7 @@ const PyExc = struct {
     pub fn raise(comptime self: Self, message: [:0]const u8) PyError {
         ffi.PyErr_SetString(self.asPyObject().py, message.ptr);
         try augmentTraceback();
-        return PyError.Raised;
+        return PyError.PyRaised;
     }
 
     pub fn raiseFmt(comptime self: Self, comptime fmt: [:0]const u8, args: anytype) PyError {

--- a/pydust/src/types/float.zig
+++ b/pydust/src/types/float.zig
@@ -25,7 +25,7 @@ pub const PyFloat = extern struct {
     pub usingnamespace PyObjectMixin("float", "PyFloat", @This());
 
     pub fn create(value: anytype) !PyFloat {
-        const pyfloat = ffi.PyFloat_FromDouble(@floatCast(value)) orelse return PyError.Propagate;
+        const pyfloat = ffi.PyFloat_FromDouble(@floatCast(value)) orelse return PyError.PyRaised;
         return .{ .obj = .{ .py = pyfloat } };
     }
 
@@ -33,7 +33,7 @@ pub const PyFloat = extern struct {
         return switch (T) {
             f32, f64 => {
                 const double = ffi.PyFloat_AsDouble(self.obj.py);
-                if (ffi.PyErr_Occurred() != null) return PyError.Propagate;
+                if (ffi.PyErr_Occurred() != null) return PyError.PyRaised;
                 return @floatCast(double);
             },
             else => @compileError("Unsupported float type " ++ @typeName(T)),

--- a/pydust/src/types/list.zig
+++ b/pydust/src/types/list.zig
@@ -27,7 +27,7 @@ pub const PyList = extern struct {
     pub usingnamespace PyObjectMixin("list", "PyList", @This());
 
     pub fn new(size: usize) !PyList {
-        const list = ffi.PyList_New(@intCast(size)) orelse return PyError.Propagate;
+        const list = ffi.PyList_New(@intCast(size)) orelse return PyError.PyRaised;
         return .{ .obj = .{ .py = list } };
     }
 
@@ -40,7 +40,7 @@ pub const PyList = extern struct {
         if (ffi.PyList_GetItem(self.obj.py, idx)) |item| {
             return py.as(T, py.PyObject{ .py = item });
         } else {
-            return PyError.Propagate;
+            return PyError.PyRaised;
         }
     }
 
@@ -49,7 +49,7 @@ pub const PyList = extern struct {
         if (ffi.PyList_GetSlice(self.obj.py, low, high)) |item| {
             return .{ .obj = .{ .py = item } };
         } else {
-            return PyError.Propagate;
+            return PyError.PyRaised;
         }
     }
 
@@ -57,7 +57,7 @@ pub const PyList = extern struct {
     pub fn setOwnedItem(self: PyList, pos: isize, value: anytype) !void {
         // Since this function steals the reference, it can only accept object-like values.
         if (ffi.PyList_SetItem(self.obj.py, pos, py.object(value).py) < 0) {
-            return PyError.Propagate;
+            return PyError.PyRaised;
         }
     }
 
@@ -72,7 +72,7 @@ pub const PyList = extern struct {
         const valueObj = try py.create(value);
         defer valueObj.decref();
         if (ffi.PyList_Insert(self.obj.py, idx, valueObj.py) < 0) {
-            return PyError.Propagate;
+            return PyError.PyRaised;
         }
     }
 
@@ -82,26 +82,26 @@ pub const PyList = extern struct {
         defer valueObj.decref();
 
         if (ffi.PyList_Append(self.obj.py, valueObj.py) < 0) {
-            return PyError.Propagate;
+            return PyError.PyRaised;
         }
     }
 
     // Sort the items of list in place.
     pub fn sort(self: PyList) !void {
         if (ffi.PyList_Sort(self.obj.py) < 0) {
-            return PyError.Propagate;
+            return PyError.PyRaised;
         }
     }
 
     // Reverse the items of list in place.
     pub fn reverse(self: PyList) !void {
         if (ffi.PyList_Reverse(self.obj.py) < 0) {
-            return PyError.Propagate;
+            return PyError.PyRaised;
         }
     }
 
     pub fn toTuple(self: PyList) !py.PyTuple {
-        const pytuple = ffi.PyList_AsTuple(self.obj.py) orelse return PyError.Propagate;
+        const pytuple = ffi.PyList_AsTuple(self.obj.py) orelse return PyError.PyRaised;
         return py.PyTuple.unchecked(.{ .py = pytuple });
     }
 };

--- a/pydust/src/types/long.zig
+++ b/pydust/src/types/long.zig
@@ -33,7 +33,7 @@ pub const PyLong = extern struct {
         const pylong = switch (typeInfo.signedness) {
             .signed => ffi.PyLong_FromLongLong(@intCast(value)),
             .unsigned => ffi.PyLong_FromUnsignedLongLong(@intCast(value)),
-        } orelse return PyError.Propagate;
+        } orelse return PyError.PyRaised;
 
         return .{ .obj = .{ .py = pylong } };
     }
@@ -44,12 +44,12 @@ pub const PyLong = extern struct {
         return switch (typeInfo.signedness) {
             .signed => {
                 const ll = ffi.PyLong_AsLongLong(self.obj.py);
-                if (ffi.PyErr_Occurred() != null) return PyError.Propagate;
+                if (ffi.PyErr_Occurred() != null) return PyError.PyRaised;
                 return @intCast(ll);
             },
             .unsigned => {
                 const ull = ffi.PyLong_AsUnsignedLongLong(self.obj.py);
-                if (ffi.PyErr_Occurred() != null) return PyError.Propagate;
+                if (ffi.PyErr_Occurred() != null) return PyError.PyRaised;
                 return @intCast(ull);
             },
         };
@@ -70,7 +70,7 @@ test "PyLong" {
     defer neg_pl.decref();
 
     try std.testing.expectError(
-        PyError.Propagate,
+        PyError.PyRaised,
         neg_pl.as(c_ulong),
     );
 }

--- a/pydust/src/types/module.zig
+++ b/pydust/src/types/module.zig
@@ -25,26 +25,26 @@ pub const PyModule = extern struct {
     pub usingnamespace PyObjectMixin("module", "PyModule", @This());
 
     pub fn import(name: [:0]const u8) !PyModule {
-        return .{ .obj = .{ .py = ffi.PyImport_ImportModule(name) orelse return PyError.Propagate } };
+        return .{ .obj = .{ .py = ffi.PyImport_ImportModule(name) orelse return PyError.PyRaised } };
     }
 
     pub fn getState(self: *const PyModule, comptime state: type) !*state {
-        const statePtr = ffi.PyModule_GetState(self.obj.py) orelse return PyError.Propagate;
+        const statePtr = ffi.PyModule_GetState(self.obj.py) orelse return PyError.PyRaised;
         return @ptrCast(@alignCast(statePtr));
     }
 
     pub fn addObjectRef(self: *const PyModule, name: [:0]const u8, obj: py.PyObject) !void {
         if (ffi.PyModule_AddObjectRef(self.obj.py, name.ptr, obj.py) < 0) {
-            return PyError.Propagate;
+            return PyError.PyRaised;
         }
     }
 
     /// Create and insantiate a PyModule object from a Python code string.
     pub fn fromCode(code: []const u8, filename: []const u8, module_name: []const u8) !PyModule {
-        const pycode = ffi.Py_CompileString(code.ptr, filename.ptr, ffi.Py_file_input) orelse return PyError.Propagate;
+        const pycode = ffi.Py_CompileString(code.ptr, filename.ptr, ffi.Py_file_input) orelse return PyError.PyRaised;
         defer ffi.Py_DECREF(pycode);
 
-        const pymod = ffi.PyImport_ExecCodeModuleEx(module_name.ptr, pycode, filename.ptr) orelse return PyError.Propagate;
+        const pymod = ffi.PyImport_ExecCodeModuleEx(module_name.ptr, pycode, filename.ptr) orelse return PyError.PyRaised;
         return .{ .obj = .{ .py = pymod } };
     }
 };

--- a/pydust/src/types/sequence.zig
+++ b/pydust/src/types/sequence.zig
@@ -19,13 +19,13 @@ pub fn SequenceMixin(comptime Self: type) type {
     return struct {
         pub fn contains(self: Self, value: anytype) !bool {
             const result = ffi.PySequence_Contains(self.obj.py, py.object(value).py);
-            if (result < 0) return PyError.Propagate;
+            if (result < 0) return PyError.PyRaised;
             return result == 1;
         }
 
         pub fn index(self: Self, value: anytype) !usize {
             const idx = ffi.PySequence_Index(self.obj.py, py.object(value).py);
-            if (idx < 0) return PyError.Propagate;
+            if (idx < 0) return PyError.PyRaised;
             return @intCast(idx);
         }
     };

--- a/pydust/src/types/str.zig
+++ b/pydust/src/types/str.zig
@@ -24,7 +24,7 @@ pub const PyString = extern struct {
     pub usingnamespace PyObjectMixin("str", "PyUnicode", @This());
 
     pub fn create(value: []const u8) !PyString {
-        const unicode = ffi.PyUnicode_FromStringAndSize(value.ptr, @intCast(value.len)) orelse return PyError.Propagate;
+        const unicode = ffi.PyUnicode_FromStringAndSize(value.ptr, @intCast(value.len)) orelse return PyError.PyRaised;
         return .{ .obj = .{ .py = unicode } };
     }
 
@@ -61,13 +61,13 @@ pub const PyString = extern struct {
             return PyString.unchecked(.{ .py = ptr });
         } else {
             // If set to null, then it failed.
-            return PyError.Propagate;
+            return PyError.PyRaised;
         }
     }
 
     /// Concat other to self. Returns a new reference.
     pub fn concat(self: PyString, other: PyString) !PyString {
-        const result = ffi.PyUnicode_Concat(self.obj.py, other.obj.py) orelse return PyError.Propagate;
+        const result = ffi.PyUnicode_Concat(self.obj.py, other.obj.py) orelse return PyError.PyRaised;
         return PyString.unchecked(.{ .py = result });
     }
 
@@ -87,7 +87,7 @@ pub const PyString = extern struct {
     /// Returns a view over the PyString bytes.
     pub fn asSlice(self: PyString) ![:0]const u8 {
         var size: i64 = 0;
-        const buffer: [*:0]const u8 = ffi.PyUnicode_AsUTF8AndSize(self.obj.py, &size) orelse return PyError.Propagate;
+        const buffer: [*:0]const u8 = ffi.PyUnicode_AsUTF8AndSize(self.obj.py, &size) orelse return PyError.PyRaised;
         return buffer[0..@as(usize, @intCast(size)) :0];
     }
 };

--- a/pydust/src/types/tuple.zig
+++ b/pydust/src/types/tuple.zig
@@ -59,7 +59,7 @@ pub const PyTuple = extern struct {
     }
 
     pub fn new(size: usize) !PyTuple {
-        const tuple = ffi.PyTuple_New(@intCast(size)) orelse return PyError.Propagate;
+        const tuple = ffi.PyTuple_New(@intCast(size)) orelse return PyError.PyRaised;
         return .{ .obj = .{ .py = tuple } };
     }
 
@@ -75,7 +75,7 @@ pub const PyTuple = extern struct {
         if (ffi.PyTuple_GetItem(self.obj.py, idx)) |item| {
             return py.as(T, py.PyObject{ .py = item });
         } else {
-            return PyError.Propagate;
+            return PyError.PyRaised;
         }
     }
 
@@ -84,14 +84,14 @@ pub const PyTuple = extern struct {
     /// Warning: steals a reference to value.
     pub fn setOwnedItem(self: *const PyTuple, pos: isize, value: PyObject) !void {
         if (ffi.PyTuple_SetItem(self.obj.py, @intCast(pos), value.py) < 0) {
-            return PyError.Propagate;
+            return PyError.PyRaised;
         }
     }
 
     /// Insert a reference to object o at position pos of the tuple. Does not steal a reference to value.
     pub fn setItem(self: *const PyTuple, pos: isize, value: PyObject) !void {
         if (ffi.PyTuple_SetItem(self.obj.py, @intCast(pos), value.py) < 0) {
-            return PyError.Propagate;
+            return PyError.PyRaised;
         }
         // PyTuple_SetItem steals a reference to value. We want the default behaviour not to do that.
         // See setOwnedItem for an implementation that does steal.

--- a/test/test_exceptions.py
+++ b/test/test_exceptions.py
@@ -21,3 +21,9 @@ def test_exceptions():
     with pytest.raises(ValueError) as exc:
         exceptions.raise_value_error("hello!")
     assert str(exc.value) == "hello!"
+
+
+def test_custom_error():
+    with pytest.raises(RuntimeError) as exc:
+        exceptions.raise_custom_error()
+    assert str(exc.value) == "Oops"


### PR DESCRIPTION
* Combine PyError.Propagate with PyError.Raised
* Allow the user to return non-PyError errors and coerce them by raising Python RuntimeError
* Make all calls into user code take optional errors (e.g. __new__ doesn't _need_ to raise anymore)