### PR TITLE
Fix errors inline else

### DIFF
--- a/pydust/src/trampoline.zig
+++ b/pydust/src/trampoline.zig
@@ -389,13 +389,10 @@ pub fn Trampoline(comptime T: type) type {
 pub fn coerceError(result: anytype) coerceErrorType(@TypeOf(result)) {
     const typeInfo = @typeInfo(@TypeOf(result));
     if (typeInfo == .ErrorUnion) {
-        return result catch |err| switch (err) {
-            inline else => |e| {
-                if (e == PyError.PyRaised or e == PyError.OutOfMemory) {
-                    return e;
-                }
-                return py.RuntimeError.raise(@errorName(e));
-            },
+        return result catch |err| {
+            if (err == PyError.PyRaised) return PyError.PyRaised;
+            if (err == PyError.OutOfMemory) return PyError.OutOfMemory;
+            return py.RuntimeError.raise(@errorName(err));
         };
     } else {
         return result;


### PR DESCRIPTION
Inline else couldn't enumerate the global error set. So instead I use if statements to catch the known Python errors, then return generic Python error for all other custom errors.