### PR TITLE
Bitcast hash result

### DIFF
--- a/example/classes.zig
+++ b/example/classes.zig
@@ -159,7 +159,7 @@ pub const Hash = py.class(struct {
 
     pub fn __hash__(self: *const Self) usize {
         var hasher = std.hash.Wyhash.init(0);
-        std.hash.autoHashStrat(&hasher, self.wrapped, .DeepRecursive);
+        std.hash.autoHashStrat(&hasher, self, .DeepRecursive);
         return hasher.final();
     }
 });

--- a/example/classes.zig
+++ b/example/classes.zig
@@ -157,8 +157,10 @@ pub const Hash = py.class(struct {
         return .{ .number = args.x };
     }
 
-    pub fn __hash__(self: *const Self) u32 {
-        return std.hash.Murmur3_32.hashUint32(@intCast(self.number));
+    pub fn __hash__(self: *const Self) usize {
+        var hasher = std.hash.Wyhash.init(0);
+        std.hash.autoHashStrat(&hasher, self.wrapped, .DeepRecursive);
+        return hasher.final();
     }
 });
 // --8<-- [end:zigonly]

--- a/pydust/src/pytypes.zig
+++ b/pydust/src/pytypes.zig
@@ -365,7 +365,7 @@ fn Slots(comptime definition: type, comptime name: [:0]const u8) type {
         fn tp_hash(pyself: *ffi.PyObject) callconv(.C) ffi.Py_hash_t {
             const self: *PyTypeStruct(definition) = @ptrCast(pyself);
             const result = tramp.coerceError(definition.__hash__(&self.state)) catch return -1;
-            return @as(isize, @intCast(result));
+            return @as(isize, @bitCast(result));
         }
     };
 }

--- a/pydust/src/types/obj.zig
+++ b/pydust/src/types/obj.zig
@@ -116,7 +116,7 @@ pub fn PyObjectMixin(comptime name: []const u8, comptime prefix: []const u8, com
         /// Checked conversion from a PyObject.
         pub fn checked(obj: py.PyObject) !Self {
             if (PyCheck(obj.py) == 0) {
-                return py.TypeError.raise("expected " ++ name);
+                return py.TypeError.raiseFmt("expected {s}, found {s}", .{ name, try (try py.str(try py.type_(obj))).asSlice() });
             }
             return .{ .obj = obj };
         }

--- a/test/test_classes.py
+++ b/test/test_classes.py
@@ -78,4 +78,4 @@ def test_attributes():
 
 def test_hash():
     h = classes.Hash(42)
-    assert hash(h) == 1558143690
+    assert hash(h) == -7849439630130923510


### PR DESCRIPTION
tp_hash result is signed 64 bits, but it doesn't actually matter so long as there are 64 bits.