### PR TITLE
[break] Refactor call API

### DIFF
--- a/pydust/src/builtins.zig
+++ b/pydust/src/builtins.zig
@@ -72,12 +72,20 @@ pub fn callable(object: anytype) bool {
 }
 
 /// Call a callable object with no arguments.
+///
+/// If the result is a new reference, then as always the caller is responsible for calling decref on it.
+/// That means for new references the caller should ask for a return type that they are unable to decref,
+/// for example []const u8.
 pub fn call0(comptime T: type, object: anytype) !T {
     const result = ffi.PyObject_CallNoArgs(py.object(object).py) orelse return PyError.PyRaised;
     return try py.as(T, result);
 }
 
 /// Call a callable object with the given arguments.
+///
+/// If the result is a new reference, then as always the caller is responsible for calling decref on it.
+/// That means for new references the caller should ask for a return type that they are unable to decref,
+/// for example []const u8.
 pub fn call(comptime ReturnType: type, object: anytype, args: anytype, kwargs: anytype) !ReturnType {
     const pyobj = py.object(object);
 
@@ -106,7 +114,7 @@ pub fn call(comptime ReturnType: type, object: anytype, args: anytype, kwargs: a
     }
     defer kwargsPy.decref();
 
-    // We _must_ return a PyObject to the user to let them handle the lifetime of the object.
+    // Note, the caller is responsible for returning a result type that they are able to decref.
     const result = ffi.PyObject_Call(pyobj.py, argsPy.obj.py, kwargsPy.obj.py) orelse return PyError.PyRaised;
     return try py.as(ReturnType, result);
 }

--- a/pydust/src/modules.zig
+++ b/pydust/src/modules.zig
@@ -124,11 +124,11 @@ fn Slots(comptime definition: type) type {
                 const pySubmodDef: *ffi.PyModuleDef = @ptrCast((try submodDef.init()).py);
 
                 // Create a dumb ModuleSpec with a name attribute using types.SimpleNamespace
-                const SimpleNamespace = try py.importFrom("types", "SimpleNamespace");
-
+                const types = try py.import("types");
+                defer types.decref();
                 const pyname = try py.PyString.create(name);
                 defer pyname.decref();
-                const spec = try SimpleNamespace.call(.{}, .{ .name = pyname });
+                const spec = try types.call(py.PyObject, "SimpleNamespace", .{}, .{ .name = pyname });
                 defer spec.decref();
 
                 const submod: py.PyObject = .{ .py = ffi.PyModule_FromDefAndSpec(pySubmodDef, spec.py) orelse return PyError.PyRaised };

--- a/pydust/src/types/slice.zig
+++ b/pydust/src/types/slice.zig
@@ -36,15 +36,15 @@ pub const PySlice = extern struct {
     }
 
     pub fn getStart(self: PySlice, comptime T: type) !T {
-        return try py.as(T, try self.obj.get("start"));
+        return try self.obj.getAs(T, "start");
     }
 
     pub fn getStop(self: PySlice, comptime T: type) !T {
-        return try py.as(T, try self.obj.get("stop"));
+        return try try self.obj.getAs(T, "stop");
     }
 
     pub fn getStep(self: PySlice, comptime T: type) !T {
-        return try py.as(T, try self.obj.get("step"));
+        return try self.obj.getAs(T, "step");
     }
 };
 

--- a/pydust/src/types/type.zig
+++ b/pydust/src/types/type.zig
@@ -53,7 +53,7 @@ test "PyType" {
     defer StringIO.decref();
     try std.testing.expectEqualSlices(u8, "StringIO", try (try StringIO.name()).asSlice());
 
-    const sio = try StringIO.obj.call0();
+    const sio = try py.call0(py.PyObject, StringIO);
     defer sio.decref();
     const sioType = try py.type_(sio);
     try std.testing.expectEqualSlices(u8, "StringIO", try (try sioType.name()).asSlice());

--- a/pydust/src/types/type.zig
+++ b/pydust/src/types/type.zig
@@ -49,8 +49,10 @@ test "PyType" {
     py.initialize();
     defer py.finalize();
 
-    const StringIO = try PyType.checked(try py.importFrom("io", "StringIO"));
-    defer StringIO.decref();
+    const io = try py.import("io");
+    defer io.decref();
+
+    const StringIO = try io.getAs(py.PyType, "StringIO");
     try std.testing.expectEqualSlices(u8, "StringIO", try (try StringIO.name()).asSlice());
 
     const sio = try py.call0(py.PyObject, StringIO);


### PR DESCRIPTION
Callable objects can now be called using `py.call` and `py.call0`, and the `PyObject.call` methods now take a method name argument.