### PR TITLE
Add call0 to PyObject

### DIFF
--- a/pydust/src/builtins.zig
+++ b/pydust/src/builtins.zig
@@ -138,13 +138,6 @@ pub fn import(module_name: [:0]const u8) !py.PyObject {
     return (try py.PyModule.import(module_name)).obj;
 }
 
-/// Import a module and return a borrowed reference to an attribute on that module.
-pub fn importFrom(module_name: [:0]const u8, attr: [:0]const u8) !py.PyObject {
-    const mod = try import(module_name);
-    defer mod.decref();
-    return try mod.get(attr);
-}
-
 /// Check if object is an instance of cls.
 pub fn isinstance(object: anytype, cls: anytype) !bool {
     const pyobj = py.object(object);
@@ -229,7 +222,9 @@ pub fn self(comptime PydustType: type) !py.PyObject {
     const mod = State.getContaining(PydustType, .module);
     const modName = State.getIdentifier(mod).name;
 
-    return try importFrom(modName, clsName);
+    const pymod = try import(modName);
+    defer pymod.decref();
+    return pymod.get(clsName);
 }
 
 const testing = std.testing;

--- a/pydust/src/types/obj.zig
+++ b/pydust/src/types/obj.zig
@@ -33,7 +33,12 @@ pub const PyObject = extern struct {
         return name.asSlice();
     }
 
-    /// Call this object with the given args and kwargs.
+    /// Call a method on this object with no arguments.
+    pub fn call0(self: PyObject, comptime T: type, method: [:0]const u8) !T {
+        return py.call0(T, try self.get(method));
+    }
+
+    /// Call a method on this object with the given args and kwargs.
     pub fn call(self: PyObject, comptime T: type, method: [:0]const u8, args: anytype, kwargs: anytype) !T {
         const methodObj = try self.get(method);
         return py.call(T, methodObj, args, kwargs);
@@ -125,7 +130,9 @@ test "call" {
     py.initialize();
     defer py.finalize();
 
-    const pow = try py.importFrom("math", "pow");
-    const result = try py.call(f32, pow, .{ 2, 3 }, .{});
+    const math = try py.import("math");
+    defer math.decref();
+
+    const result = try math.call(f32, "pow", .{ 2, 3 }, .{});
     try std.testing.expectEqual(@as(f32, 8.0), result);
 }

--- a/pydust/src/types/slice.zig
+++ b/pydust/src/types/slice.zig
@@ -40,7 +40,7 @@ pub const PySlice = extern struct {
     }
 
     pub fn getStop(self: PySlice, comptime T: type) !T {
-        return try try self.obj.getAs(T, "stop");
+        return try self.obj.getAs(T, "stop");
     }
 
     pub fn getStep(self: PySlice, comptime T: type) !T {
@@ -56,5 +56,6 @@ test "PySlice" {
     defer range.decref();
 
     try std.testing.expectEqual(@as(u64, 0), try range.getStart(u64));
+    try std.testing.expectEqual(@as(u64, 100), try range.getStop(u64));
     try std.testing.expectEqual(@as(?u64, null), try range.getStep(?u64));
 }


### PR DESCRIPTION
We also remove importFrom since it can be confusing about what to decref. `py.import` makes it obvious you need to release the reference afterward, and the new call API removes the need for importFrom in most cases.