### PR TITLE
Fix null termination

### DIFF
--- a/pydust/src/types/error.zig
+++ b/pydust/src/types/error.zig
@@ -166,19 +166,11 @@ const PyExc = struct {
                 );
                 defer py.allocator.free(code);
 
-                // We have to copy all the strings to ensure they're null terminated :(
-                const func_name = try py.allocator.dupeZ(u8, symbol_info.symbol_name);
-                defer py.allocator.free(func_name);
-                const file_name = try py.allocator.dupeZ(u8, line_info.file_name);
-                defer py.allocator.free(file_name);
-                const compile_unit_name = try py.allocator.dupeZ(u8, symbol_info.compile_unit_name);
-                defer py.allocator.free(compile_unit_name);
-
                 // Import the compiled code as a module and invoke the failing function
-                const fake_module = try py.PyModule.fromCode(code, file_name, compile_unit_name);
+                const fake_module = try py.PyModule.fromCode(code, line_info.file_name, symbol_info.compile_unit_name);
                 defer fake_module.decref();
 
-                _ = fake_module.obj.call(void, func_name, .{}, .{}) catch null;
+                _ = fake_module.obj.call(void, symbol_info.symbol_name, .{}, .{}) catch null;
 
                 // Grab our forced exception info.
                 // We can ignore qtype and qvalue, we just want to get the traceback object.

--- a/pydust/src/types/error.zig
+++ b/pydust/src/types/error.zig
@@ -166,12 +166,17 @@ const PyExc = struct {
                 );
                 defer py.allocator.free(code);
 
-                // Import the compiled code as a module and invoke the failing function
-                const fake_module = try py.PyModule.fromCode(code, line_info.file_name, symbol_info.compile_unit_name);
-                defer fake_module.decref();
-
+                // We have to copy all the strings to ensure they're null terminated :(
                 const func_name = try py.allocator.dupeZ(u8, symbol_info.symbol_name);
                 defer py.allocator.free(func_name);
+                const file_name = try py.allocator.dupeZ(u8, line_info.file_name);
+                defer py.allocator.free(file_name);
+                const compile_unit_name = try py.allocator.dupeZ(u8, symbol_info.compile_unit_name);
+                defer py.allocator.free(compile_unit_name);
+
+                // Import the compiled code as a module and invoke the failing function
+                const fake_module = try py.PyModule.fromCode(code, file_name, compile_unit_name);
+                defer fake_module.decref();
 
                 _ = fake_module.obj.call(void, func_name, .{}, .{}) catch null;
 


### PR DESCRIPTION
Fixes #181 

In general, we should accept `[]const u8` and return `[:0]const u8` where possible.

We switch from using PyObject_GetAttrString and equivalents to PyObject_GetAttr since the former simply creates a PyUnicode object anyway. By creating the object ourselves, we're able to construct it from non-null terminated slices without making a second copy.

The actual bug we had, was the `PyModule.from_code` function was using `[]const u8` slices as `value.ptr` without requirement them to be null terminated.