### PR TITLE
Default handling for __eq__ with typed other

### DIFF
--- a/pydust/src/pytypes.zig
+++ b/pydust/src/pytypes.zig
@@ -614,7 +614,7 @@ fn EqualsOperator(
             if (sig.nargs != 1) @compileError(op ++ " must take exactly one parameter after self parameter");
 
             // If other arg is of the same type as self we can short circuit equality of both objects aren't of same type
-            if (sig.argsParam == *definition or sig.argsParam == *const definition) {
+            if (sig.argsParam == *const definition) {
                 const selfType = py.type_(py.object(pyself)) catch return null;
                 const otherType = py.type_(py.object(pyother)) catch return null;
                 if (otherType.obj.py != selfType.obj.py) {

--- a/test/test_operators.py
+++ b/test/test_operators.py
@@ -133,6 +133,13 @@ def test_justequals():
         assert cmp1 <= cmp2
 
 
+def test_justequals_different_type():
+    cmp1 = operators.Equals(1)
+    cmp2 = 2
+
+    assert not cmp1 == cmp2
+
+
 def test_justLessThan():
     cmp1 = operators.LessThan("abc")
     cmp2 = operators.LessThan("abd")

--- a/test/test_operators.py
+++ b/test/test_operators.py
@@ -133,11 +133,14 @@ def test_justequals():
         assert cmp1 <= cmp2
 
 
+# Test short circuit logic in pydust that handles
+# cases where __eq__ expects same types but values clearly are not
 def test_justequals_different_type():
     cmp1 = operators.Equals(1)
     cmp2 = 2
 
     assert not cmp1 == cmp2
+    assert cmp1 != cmp2
 
 
 def test_justLessThan():


### PR DESCRIPTION
If user defines `__eq__` or `__ne__`  with other not being same type as self we perform is
instance check before delegating to user function