### PR TITLE
Fix: Use stable api way of accessing object type

### DIFF
--- a/pydust/src/builtins.zig
+++ b/pydust/src/builtins.zig
@@ -258,7 +258,7 @@ pub fn tuple(object: anytype) !py.PyTuple {
 pub fn type_(object: anytype) !py.PyType {
     return .{ .obj = .{ .py = @as(
         ?*ffi.PyObject,
-        @ptrCast(@alignCast(ffi.Py_TYPE(py.object(object).py))),
+        @ptrCast(@alignCast(py.object(object).py.ob_type)),
     ) orelse return PyError.PyRaised } };
 }
 


### PR DESCRIPTION
Per https://docs.python.org/3/c-api/typeobj.html#c.PyObject.ob_type