### PR TITLE
[do not merge] Consider removing isinstance check from trampoline

### DIFF
--- a/pydust/src/trampoline.zig
+++ b/pydust/src/trampoline.zig
@@ -223,20 +223,7 @@ pub fn Trampoline(comptime T: type) type {
 
                         // If the pointer is for a Pydust class
                         if (def.type == .class) {
-                            // TODO(ngates): #193
-                            const Cls = try py.self(p.child);
-                            defer Cls.decref();
-
-                            if (!try py.isinstance(obj, Cls)) {
-                                const clsName = State.getIdentifier(p.child).name;
-                                const mod = State.getContaining(p.child, .module);
-                                const modName = State.getIdentifier(mod).name;
-                                return py.TypeError.raiseFmt(
-                                    "Expected {s}.{s} but found {s}",
-                                    .{ modName, clsName, try obj.getTypeName() },
-                                );
-                            }
-
+                            // Note(ngates): we don't perform an isinstance check since it's potentially expensive.
                             const PyType = pytypes.PyTypeStruct(p.child);
                             const pyobject = @as(*PyType, @ptrCast(obj.py));
                             return @constCast(&pyobject.state);


### PR DESCRIPTION
Pydust performs an isinstance check inside the Trampoline.unwrap function (called from `py.as(T, pyobj)`) since this provides a nice level of automatic type-checking when invoking functions from Python.

Of course.... runtime type checking has a cost. It's not always desirable, and in the case of the `self` argument in instance/class methods it's kind of unnecessary.

Currently Pydust types are all [heap-allocated](https://docs.python.org/3/c-api/typeobj.html#heap-types) (vs [static types](https://docs.python.org/3/c-api/typeobj.html#static-types)) to allow us to compile for the limited ABI. 

Our isinstance check delegates to the Python `ffi.PyObject_IsInstance` function, which requires us to give a PyType. We grab this PyType by performing an import of the extension module and grabbing the class object from that. I'm not sure if there's a better way for heap-allocated types? Maybe we insert some global state into our generated libraries that populates on first import? Open to any other ideas?

This seems to address the performance issues in #226 , but ideally I'd like to:
1. Offer an alternative to `py.as` when knowingly converting from PyObject to PyDust class struct. #227
1. Avoid isinstance checks on self/cls parameters (probably using 1)