### PR TITLE
Fix: Don't use std.meta.trait

### DIFF
--- a/pydust/src/types/memoryview.zig
+++ b/pydust/src/types/memoryview.zig
@@ -28,7 +28,9 @@ pub const PyMemoryView = extern struct {
 
     pub fn fromSlice(slice: anytype) !PyMemoryView {
         const sliceType = Slice(@TypeOf(slice));
-        const flag = if (std.meta.trait.isConstPtr(sliceType)) PyMemoryView.Flags.PyBUF_READ else PyMemoryView.Flags.PyBUF_WRITE;
+        const sliceTpInfo = @typeInfo(sliceType);
+
+        const flag = if (sliceTpInfo == .Pointer and sliceTpInfo.Pointer.is_const) PyMemoryView.Flags.PyBUF_READ else PyMemoryView.Flags.PyBUF_WRITE;
         return .{ .obj = .{
             .py = py.ffi.PyMemoryView_FromMemory(@constCast(slice.ptr), @intCast(slice.len), flag) orelse return py.PyError.PyRaised,
         } };


### PR DESCRIPTION
std.meta.trait has been removed from standard library. Some functions have moved
to std.meta but others are simply gone https://github.com/ziglang/zig/commit/d5e21a4f1a2920ef7bbe3c54feab1a3b5119bf77
