### PR TITLE
increase eval branch quota

### DIFF
--- a/pydust/src/pydust.zig
+++ b/pydust/src/pydust.zig
@@ -120,7 +120,7 @@ fn eagerEval(comptime definition: type) void {
     }
     for (@typeInfo(definition).Struct.decls) |d| {
         const value = @field(definition, d.name);
-        @setEvalBranchQuota(2048);
+        @setEvalBranchQuota(10000);
         if (State.findDefinition(value)) |_| {
             // If it's a Pydust definition, then we identify it.
             State.identify(value, d.name ++ "", definition);

--- a/pydust/src/pydust.zig
+++ b/pydust/src/pydust.zig
@@ -120,6 +120,7 @@ fn eagerEval(comptime definition: type) void {
     }
     for (@typeInfo(definition).Struct.decls) |d| {
         const value = @field(definition, d.name);
+        @setEvalBranchQuota(2048);
         if (State.findDefinition(value)) |_| {
             // If it's a Pydust definition, then we identify it.
             State.identify(value, d.name ++ "", definition);


### PR DESCRIPTION
fixes error below (partially redacted for readability):

```
pydust/src/pydust.zig:123:33: error: evaluation exceeded 1000 backwards branches
        if (State.findDefinition(value)) |_| {
            ~~~~~~~~~~~~~~~~~~~~^~~~~~~
pydust/src/pydust.zig:123:33: note: use @setEvalBranchQuota() to raise the branch limit from 1000
```