### PR TITLE
Silence warning during build.py

### DIFF
--- a/pydust/config.py
+++ b/pydust/config.py
@@ -66,6 +66,7 @@ class ToolPydust(BaseModel):
     def validate_atts(self):
         if self.self_managed and self.ext_modules:
             raise ValueError("ext_modules cannot be defined when using Pydust in self-managed mode.")
+        return self
 
 
 @functools.cache


### PR DESCRIPTION
When running `build.py`, the following warning is issued by pydantic:

```
$ python build.py
.venv/lib/python3.13/site-packages/pydust/config.py:94: UserWarning: A custom validator is returning a value other than `self`.
Returning anything other than `self` from a top level model validator isn't supported when validating via `__init__`.
See the `model_validator` docs (https://docs.pydantic.dev/latest/concepts/validators/#model-validators) for more details.
  return ToolPydust(**pyproject["tool"].get("pydust", {}))
```

This warning is issued because there is a missing return statement in `pydust/config.py` which is interpretted as `return None` by pydantic. Returning `self` fixes the issue.

