### PR TITLE
DRY implementation

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -219,14 +219,14 @@ files = [
 
 [[package]]
 name = "click"
-version = "8.2.0"
+version = "8.2.1"
 description = "Composable command line interface toolkit"
 optional = false
 python-versions = ">=3.10"
 groups = ["main", "docs"]
 files = [
-    {file = "click-8.2.0-py3-none-any.whl", hash = "sha256:6b303f0b2aa85f1cb4e5303078fadcbcd4e476f114fab9b5007005711839325c"},
-    {file = "click-8.2.0.tar.gz", hash = "sha256:f5452aeddd9988eefa20f90f05ab66f17fce1ee2a36907fd30b05bbb5953814d"},
+    {file = "click-8.2.1-py3-none-any.whl", hash = "sha256:61a3265b914e850b85317d0b3109c7f8cd35a670f963866005d6ef1d5175a12b"},
+    {file = "click-8.2.1.tar.gz", hash = "sha256:27c491cc05d968d271d5a1db13e3b5a184636d9d930f148c50b038f0d0646202"},
 ]
 
 [package.dependencies]

--- a/pydust/src/builtins.zig
+++ b/pydust/src/builtins.zig
@@ -46,7 +46,7 @@ pub fn NotImplemented(comptime root: type) py.PyObject(root) {
 /// Returns a new reference to Py_None.
 pub fn None(comptime root: type) py.PyObject(root) {
     // It's important that we incref the Py_None singleton
-    const none = py.PyObject(root){ .py = if (ffi.PY_VERSION_HEX < 0x030D0000) 
+    const none = py.PyObject(root){ .py = if (ffi.PY_VERSION_HEX < 0x030D0000)
         ffi.Py_None()
     else
         ffi.Py_GetConstantBorrowed(ffi.Py_CONSTANT_NONE) };
@@ -274,10 +274,10 @@ pub fn self(comptime root: type, comptime Class: type) !py.PyType(root) {
 pub fn super(comptime root: type, comptime Super: type, selfInstance: anytype) !py.PyObject(root) {
     const mod = State.getContaining(root, Super, .module);
 
-    const imported = try import(root, State.getIdentifier(root, mod).name);
+    const imported = try import(root, State.getIdentifier(root, mod).name());
     defer imported.decref();
 
-    const superPyType = try imported.get(State.getIdentifier(root, Super).name);
+    const superPyType = try imported.get(State.getIdentifier(root, Super).name());
     defer superPyType.decref();
 
     const superBuiltin: py.PyObject(root) = .{ .py = @alignCast(@ptrCast(&ffi.PySuper_Type)) };

--- a/pydust/src/discovery.zig
+++ b/pydust/src/discovery.zig
@@ -21,10 +21,14 @@ const DefinitionType = enum { module, class, attribute, property };
 
 /// Captures the name of and relationships between Pydust objects.
 const Identifier = struct {
-    name: [:0]const u8,
     qualifiedName: []const [:0]const u8,
-    definition: type,
+    definition: Definition,
     parent: type,
+
+    pub fn name(self: Identifier) [:0]const u8 {
+        const qualifiedName = self.qualifiedName;
+        return qualifiedName[qualifiedName.len - 1];
+    }
 };
 
 fn countDefinitions(comptime definition: type) usize {
@@ -47,36 +51,6 @@ fn countDefinitions(comptime definition: type) usize {
         else => {},
     }
     return count;
-}
-
-fn getDefinitions(comptime definition: type) [countDefinitions(definition)]Definition {
-    comptime var definitions: [countDefinitions(definition)]Definition = undefined;
-    comptime var count = 0;
-    switch (@typeInfo(definition)) {
-        .@"struct" => |info| {
-            for (info.fields) |f| {
-                for (getDefinitions(f.type)) |subDef| {
-                    // Append the sub-definition to the list.
-                    definitions[count] = subDef;
-                    count += 1;
-                }
-            }
-            for (info.decls) |d| {
-                const field = @field(definition, d.name);
-                for (switch (@TypeOf(field)) {
-                    Definition => .{field} ++ getDefinitions(field.definition),
-                    type => getDefinitions(field), // Handle other types
-                    else => .{},
-                }) |subDef| {
-                    // Append the sub-definition to the list.
-                    definitions[count] = subDef;
-                    count += 1;
-                }
-            }
-        },
-        else => {},
-    }
-    return definitions;
 }
 
 fn getIdentifiers(
@@ -102,9 +76,8 @@ fn getIdentifiers(
                 // Handle the field based on its type
                 for (switch (@TypeOf(field)) {
                     Definition => [_]Identifier{.{
-                        .name = d.name,
                         .qualifiedName = name,
-                        .definition = field.definition,
+                        .definition = field,
                         .parent = parent,
                     }} ++ getIdentifiers(field.definition, name, definition),
                     type => getIdentifiers(field, name, definition),
@@ -119,6 +92,15 @@ fn getIdentifiers(
         else => {},
     }
     return identifiers;
+}
+
+fn getAllIdentifiers(comptime definition: type) [countDefinitions(definition) + 1]Identifier {
+    const qualifiedName = &.{@import("pyconf").module_name};
+    return [_]Identifier{.{
+        .qualifiedName = qualifiedName,
+        .definition = .{ .definition = definition, .type = .module },
+        .parent = definition,
+    }} ++ getIdentifiers(definition, qualifiedName, definition);
 }
 
 pub const State = struct {
@@ -162,9 +144,9 @@ pub const State = struct {
             Definition => definition,
             type => switch (@typeInfo(definition)) {
                 .@"struct" => blk: {
-                    for ([_]Definition{.{ .definition = root, .type = .module }} ++ getDefinitions(root)) |def| {
-                        if (def.definition == definition)
-                            break :blk def;
+                    for (getAllIdentifiers(root)) |id| {
+                        if (id.definition.definition == definition)
+                            break :blk id.definition;
                     }
                     break :blk null;
                 },
@@ -185,18 +167,12 @@ pub const State = struct {
         comptime root: type,
         comptime definition: type,
     ) ?Identifier {
-        const qualifiedName = &.{@import("pyconf").module_name};
         if (@typeInfo(definition) != .@"struct") {
             return null;
         }
-        for ([_]Identifier{.{
-            .name = qualifiedName[0],
-            .qualifiedName = qualifiedName,
-            .definition = root,
-            .parent = root,
-        }} ++ getIdentifiers(root, qualifiedName, root)) |idef| {
-            if (idef.definition == definition) {
-                return idef;
+        for (getAllIdentifiers(root)) |id| {
+            if (id.definition.definition == definition) {
+                return id;
             }
         }
         return null;
@@ -216,11 +192,11 @@ pub const State = struct {
         comptime definition: type,
         comptime deftype: DefinitionType,
     ) ?type {
-        const defs = [_]Definition{.{ .definition = root, .type = .module }} ++ getDefinitions(root);
-        var idx = defs.len;
+        const identifiers = getAllIdentifiers(root);
+        var idx = identifiers.len;
         var foundOriginal = false;
         while (idx > 0) : (idx -= 1) {
-            const def = defs[idx - 1];
+            const def = identifiers[idx - 1].definition;
 
             if (def.definition == definition) {
                 // Only once we found the original definition, should we check for deftype.

--- a/pydust/src/modules.zig
+++ b/pydust/src/modules.zig
@@ -139,7 +139,7 @@ fn Slots(comptime root: type, comptime definition: type) type {
                 // which is a dumb object containing only a name.
                 // See https://github.com/python/cpython/blob/042f31da552c19054acd3ef7bb6cfd857bce172b/Python/import.c#L2527-L2539
 
-                const name = State.getIdentifier(root, submodule).name;
+                const name = comptime State.getIdentifier(root, submodule).name();
                 const submodDef = Module(root, name, submodule);
                 const pySubmodDef: *ffi.PyModuleDef = @ptrCast((try submodDef.init()).py);
 

--- a/pydust/src/pytypes.zig
+++ b/pydust/src/pytypes.zig
@@ -37,7 +37,7 @@ pub fn PyTypeStruct(comptime definition: type) type {
 pub fn Type(comptime root: type, comptime name: [:0]const u8, comptime definition: type) type {
     return struct {
         const qualifiedName: [:0]const u8 = blk: {
-            const moduleName = State.getIdentifier(root, State.getContaining(root, definition, .module)).name;
+            const moduleName = State.getIdentifier(root, State.getContaining(root, definition, .module)).name();
             break :blk moduleName ++ "." ++ name;
         };
 

--- a/pydust/src/trampoline.zig
+++ b/pydust/src/trampoline.zig
@@ -229,9 +229,9 @@ pub fn Trampoline(comptime root: type, comptime T: type) type {
                             defer Cls.decref();
 
                             if (!try py.isinstance(root, obj, Cls)) {
-                                const clsName = State.getIdentifier(root, p.child).name;
+                                const clsName = State.getIdentifier(root, p.child).name();
                                 const mod = State.getContaining(root, p.child, .module);
-                                const modName = State.getIdentifier(root, mod).name;
+                                const modName = State.getIdentifier(root, mod).name();
                                 return py.TypeError(root).raiseFmt(
                                     "Expected {s}.{s} but found {s}",
                                     .{ modName, clsName, try obj.getTypeName() },


### PR DESCRIPTION
#429 duplicated code to gather `definitions` and `identifiers`.  This PR merges the two and removes the corresponding code duplication.