### PR TITLE
fix traceback & GC.tp_clear crash

### DIFF
--- a/example/classes.zig
+++ b/example/classes.zig
@@ -108,6 +108,7 @@ pub const User = py.class(struct {
     pub fn __del__(self: *Self) void {
         self.name.obj.decref();
         if (self.email.e) |e| e.obj.decref();
+        self.email.e = null;
     }
 });
 // --8<-- [end:properties]

--- a/example/classes.zig
+++ b/example/classes.zig
@@ -107,7 +107,7 @@ pub const User = py.class(struct {
 
     pub fn __del__(self: *Self) void {
         self.name.obj.decref();
-        if (self.email.e) |e| e.obj.decref();
+        // if (self.email.e) |e| e.obj.decref();
     }
 });
 // --8<-- [end:properties]

--- a/example/classes.zig
+++ b/example/classes.zig
@@ -107,7 +107,7 @@ pub const User = py.class(struct {
 
     pub fn __del__(self: *Self) void {
         self.name.obj.decref();
-        // if (self.email.e) |e| e.obj.decref();
+        if (self.email.e) |e| e.obj.decref();
     }
 });
 // --8<-- [end:properties]

--- a/pydust/src/pytypes.zig
+++ b/pydust/src/pytypes.zig
@@ -515,8 +515,8 @@ fn GC(comptime root: type, comptime definition: type) type {
         }
 
         fn clearFields(class: anytype) void {
-            inline for (@typeInfo(@TypeOf(class)).@"struct".fields) |_| {
-                // clear(@field(class, field.name));    // TODO: uncomment this
+            inline for (@typeInfo(@TypeOf(class)).@"struct".fields) |field| {
+                clear(@field(class, field.name));
             }
         }
 

--- a/pydust/src/pytypes.zig
+++ b/pydust/src/pytypes.zig
@@ -555,7 +555,7 @@ fn GC(comptime root: type, comptime definition: type) type {
                         return;
                     }
 
-                    clear(obj.?);
+                    // clear(obj.?); // assuming that the optional is do Py_DECREF outside.
                 },
                 else => {},
             }

--- a/pydust/src/pytypes.zig
+++ b/pydust/src/pytypes.zig
@@ -515,8 +515,8 @@ fn GC(comptime root: type, comptime definition: type) type {
         }
 
         fn clearFields(class: anytype) void {
-            inline for (@typeInfo(@TypeOf(class)).@"struct".fields) |field| {
-                clear(@field(class, field.name));
+            inline for (@typeInfo(@TypeOf(class)).@"struct".fields) |_| {
+                // clear(@field(class, field.name));    // TODO: uncomment this
             }
         }
 

--- a/pydust/src/types/error.zig
+++ b/pydust/src/types/error.zig
@@ -255,12 +255,6 @@ fn PyExc(comptime root: type, comptime name: [:0]const u8) type {
         /// Warning: hackery ahead!
         fn augmentTraceback() PyError!void {
             if (builtin.mode == .Debug) {
-                // First of all, grab the current Python exception
-                var ptype: ?*ffi.PyObject = undefined;
-                var pvalue: ?*ffi.PyObject = undefined;
-                var ptraceback: ?*ffi.PyObject = undefined;
-                ffi.PyErr_Fetch(&ptype, &pvalue, &ptraceback);
-
                 // Capture at most 32 stack frames above us.
                 var addresses: [32]usize = undefined;
                 var st: std.builtin.StackTrace = .{
@@ -270,10 +264,14 @@ fn PyExc(comptime root: type, comptime name: [:0]const u8) type {
                 std.debug.captureStackTrace(@returnAddress(), &st);
 
                 const debugInfo = std.debug.getSelfDebugInfo() catch return;
+                const stderr = std.io.getStdErr();
 
                 // Skip the first frame (this function) and the last frame (the trampoline entrypoint)
                 for (0..st.index) |idx| {
                     // std.debug.writeStackTrace subtracts 1 from the address - not sure why, but it gives accurate frames.
+                    if (st.instruction_addresses[idx] == 0) {
+                        continue; // Skip empty addresses
+                    }
                     const address = st.instruction_addresses[idx] - 1;
 
                     // If we can't find info for the stack frame, then we skip this frame..
@@ -286,51 +284,9 @@ fn PyExc(comptime root: type, comptime name: [:0]const u8) type {
                         continue;
                     }
 
-                    // Allocate a string of newlines.
-                    // Since we wrap the error in a function, we have an addition "def foo()" line.
-                    // In addition to lineno being zero-based, we have to subtract 2.
-                    // This means that exceptions on line 1 will be off... but that's quite rare.
-                    const nnewlines = if (line_info.line < 2) 0 else line_info.line - 2;
-                    const newlines = try py.allocator.alloc(u8, nnewlines);
-                    defer py.allocator.free(newlines);
-                    @memset(newlines, '\n');
-
-                    // Setup a function we know will fail (with DivideByZero error)
-                    const code = try std.fmt.allocPrintZ(
-                        py.allocator,
-                        "{s}def {s}():\n    1/0\n",
-                        .{ newlines, symbol_info.name },
-                    );
-                    defer py.allocator.free(code);
-
-                    // Import the compiled code as a module and invoke the failing function
-                    const fake_module = try py.PyModule(root).fromCode(code, line_info.file_name, symbol_info.compile_unit_name);
-                    defer fake_module.obj.decref();
-
-                    _ = fake_module.obj.call(void, symbol_info.name, .{}, .{}) catch null;
-
-                    // Grab our forced exception info.
-                    // We can ignore qtype and qvalue, we just want to get the traceback object.
-                    var qtype: ?*ffi.PyObject = undefined;
-                    var qvalue: ?*ffi.PyObject = undefined;
-                    var qtraceback: ?*ffi.PyObject = undefined;
-                    ffi.PyErr_Fetch(&qtype, &qvalue, &qtraceback);
-                    if (qtype) |q| py.decref(root, q);
-                    if (qvalue) |q| py.decref(root, q);
-                    std.debug.assert(qtraceback != null);
-
-                    // Extract the traceback frame by calling into Python (Pytraceback isn't part of the Stable API)
-                    const pytb = py.PyObject(root){ .py = qtraceback.? };
-                    const frame = (try pytb.get("tb_frame")).py;
-
-                    // Restore the original exception, augment it with the new frame, then fetch the new exception.
-                    ffi.PyErr_Restore(ptype, pvalue, ptraceback);
-                    _ = ffi.PyTraceBack_Here(@alignCast(@ptrCast(frame)));
-                    ffi.PyErr_Fetch(&ptype, &pvalue, &ptraceback);
+                    // Print the source location of the frame.
+                    std.debug.printSourceAtAddress(debugInfo, stderr.writer(), address, std.io.tty.detectConfig(stderr)) catch unreachable;
                 }
-
-                // Restore the latest the exception info
-                ffi.PyErr_Restore(ptype, pvalue, ptraceback);
             }
         }
     };

--- a/pydust/src/types/error.zig
+++ b/pydust/src/types/error.zig
@@ -232,7 +232,7 @@ fn PyExc(comptime root: type, comptime name: [:0]const u8) type {
 
         pub fn raise(message: [:0]const u8) PyError {
             ffi.PyErr_SetString(asPyObject().py, message.ptr);
-            try augmentTraceback();
+            augmentTraceback();
             return PyError.PyRaised;
         }
 
@@ -253,7 +253,7 @@ fn PyExc(comptime root: type, comptime name: [:0]const u8) type {
 
         /// In debug mode, augment the Python traceback to include Zig stack frames.
         /// Warning: hackery ahead!
-        fn augmentTraceback() PyError!void {
+        pub fn augmentTraceback() void {
             if (builtin.mode == .Debug) {
                 // Capture at most 32 stack frames above us.
                 var addresses: [32]usize = undefined;
@@ -285,7 +285,7 @@ fn PyExc(comptime root: type, comptime name: [:0]const u8) type {
                     }
 
                     // Print the source location of the frame.
-                    std.debug.printSourceAtAddress(debugInfo, stderr.writer(), address, std.io.tty.detectConfig(stderr)) catch unreachable;
+                    std.debug.printSourceAtAddress(debugInfo, stderr.writer(), address, std.io.tty.detectConfig(stderr)) catch return;
                 }
             }
         }

--- a/pydust/src/types/obj.zig
+++ b/pydust/src/types/obj.zig
@@ -35,8 +35,7 @@ pub fn PyObject(comptime root: type) type {
         }
 
         pub fn refcnt(self: Self) isize {
-            const local_py: *CPyObject = @ptrCast(self.py);
-            return local_py.ob_refcnt;
+            return ffi.Py_REFCNT(self.py);
         }
 
         pub fn getTypeName(self: Self) ![:0]const u8 {


### PR DESCRIPTION
At my macos 15.5, `st.instruction_addresses[st.index]` is zero. But linux is OK.

- zig 0.14.0 & 0.14.1 all has crash at macos;
- use `std.debug.printSourceAtAddress` simplify `augmentTraceback` function.