### PR TITLE
fix optional decref crash

### DIFF
--- a/example/classes.zig
+++ b/example/classes.zig
@@ -108,6 +108,7 @@ pub const User = py.class(struct {
     pub fn __del__(self: *Self) void {
         self.name.obj.decref();
         if (self.email.e) |e| e.obj.decref();
+        self.email.e = null;
     }
 });
 // --8<-- [end:properties]


### PR DESCRIPTION
As I mentioned in #490 , GC.tp_clear will decref twice at `558: clear(obj.?);` reached `.optional` branch.