### PR TITLE
Run library tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,11 +62,12 @@ jobs:
         run: poetry run ruff check .
       - name: Black
         run: poetry run ruff format --check .
+      - name: Run library tests
+        run: poetry run python -m ziglang build test
       - name: Pytest
         run: poetry run pytest
       - name: Check generated stubs
         run: poetry run python -m ziglang build --build-file pytest.build.zig generate-stubs -Dcheck-stubs=true
-
       - name: Zig Docs Build
         run: poetry run python -m ziglang build docs
       - name: Setup doc deploy

--- a/pyconf.dummy.zig
+++ b/pyconf.dummy.zig
@@ -11,5 +11,6 @@
 // limitations under the License.
 
 /// This pyconf module is used during our own tests to represent the typically auto-generated pyconf module.
+pub const module_name = "test";
 pub const limited_api = true;
 pub const hexversion = "0x030D0000"; // 3.13

--- a/pydust/src/builtins.zig
+++ b/pydust/src/builtins.zig
@@ -299,27 +299,27 @@ pub fn type_(comptime root: type, object: anytype) py.PyType {
 }
 
 pub fn eq(comptime root: type, a: anytype, b: anytype) !bool {
-    return compare(root, py.object(root, a), py.object(root, b), py.CompareOp.EQ);
+    return compare(py.object(root, a), py.object(root, b), py.CompareOp.EQ);
 }
 
 pub fn ne(comptime root: type, a: anytype, b: anytype) !bool {
-    return compare(root, py.object(root, a), py.object(root, b), py.CompareOp.NE);
+    return compare(py.object(root, a), py.object(root, b), py.CompareOp.NE);
 }
 
 pub fn lt(comptime root: type, a: anytype, b: anytype) !bool {
-    return compare(root, py.object(root, a), py.object(root, b), py.CompareOp.LT);
+    return compare(py.object(root, a), py.object(root, b), py.CompareOp.LT);
 }
 
 pub fn le(comptime root: type, a: anytype, b: anytype) !bool {
-    return compare(root, py.object(root, a), py.object(root, b), py.CompareOp.LE);
+    return compare(py.object(root, a), py.object(root, b), py.CompareOp.LE);
 }
 
 pub fn gt(comptime root: type, a: anytype, b: anytype) !bool {
-    return compare(root, py.object(root, a), py.object(root, b), py.CompareOp.GT);
+    return compare(py.object(root, a), py.object(root, b), py.CompareOp.GT);
 }
 
 pub fn ge(comptime root: type, a: anytype, b: anytype) !bool {
-    return compare(root, py.object(root, a), py.object(root, b), py.CompareOp.GE);
+    return compare(py.object(root, a), py.object(root, b), py.CompareOp.GE);
 }
 
 inline fn compare(a: py.PyObject, b: py.PyObject, op: py.CompareOp) !bool {
@@ -363,7 +363,7 @@ test "is_none" {
 
     const root = @This();
 
-    const none = None(root);
+    const none = None();
     defer none.decref();
 
     try testing.expect(is_none(root, none));
@@ -376,9 +376,9 @@ test "compare" {
     const root = @This();
 
     const num = try py.PyLong.create(0);
-    defer num.decref();
+    defer num.obj.decref();
     const num2 = try py.PyLong.create(1);
-    defer num2.decref();
+    defer num2.obj.decref();
 
     try testing.expect(try le(root, num, num2));
     try testing.expect(try lt(root, num, num2));

--- a/pydust/src/conversions.zig
+++ b/pydust/src/conversions.zig
@@ -86,7 +86,7 @@ test "create" {
     defer some_tuple.decref();
     try testing.expectEqual(@as(isize, 2), py.refcnt(root, str));
 
-    str.decref();
+    str.obj.decref();
     try testing.expectEqual(@as(isize, 1), py.refcnt(root, str));
 }
 

--- a/pydust/src/pydust.zig
+++ b/pydust/src/pydust.zig
@@ -153,9 +153,6 @@ pub const ValueError = err.ValueError;
 pub const Warning = err.Warning;
 pub const WindowsError = err.WindowsError;
 pub const ZeroDivisionError = err.ZeroDivisionError;
-pub const raise = err.raise;
-pub const raiseFmt = err.raiseFmt;
-pub const raiseComptimeFmt = err.raiseComptimeFmt;
 pub const ffi = @import("ffi");
 pub const PyError = @import("errors.zig").PyError;
 pub const allocator: std.mem.Allocator = mem.PyMemAllocator.allocator();
@@ -234,4 +231,9 @@ pub fn Kwargs() type {
 /// Zig type representing `(*args, **kwargs)`
 pub fn CallArgs() type {
     return struct { args: Args, kwargs: Kwargs };
+}
+
+test {
+    // See https://ziggit.dev/t/how-do-i-get-zig-build-to-run-all-the-tests/4434/2
+    std.testing.refAllDecls(@This());
 }

--- a/pydust/src/types/bool.zig
+++ b/pydust/src/types/bool.zig
@@ -55,10 +55,10 @@ test "PyBool" {
     defer py.finalize();
 
     const pytrue = PyBool.true_();
-    defer pytrue.decref();
+    defer pytrue.obj.decref();
 
     const pyfalse = PyBool.false_();
-    defer pyfalse.decref();
+    defer pyfalse.obj.decref();
 
     try std.testing.expect(pytrue.asbool());
     try std.testing.expect(!pyfalse.asbool());

--- a/pydust/src/types/bytes.zig
+++ b/pydust/src/types/bytes.zig
@@ -57,11 +57,10 @@ test "PyBytes" {
     py.initialize();
     defer py.finalize();
 
-    const root = @This();
     const a = "Hello";
 
-    var ps = try PyBytes(root).create(a);
-    defer ps.decref();
+    var ps = try PyBytes.create(a);
+    defer ps.obj.decref();
 
     const ps_slice = try ps.asSlice();
     try testing.expectEqual(a.len, ps_slice.len);

--- a/pydust/src/types/dict.zig
+++ b/pydust/src/types/dict.zig
@@ -192,10 +192,10 @@ test "PyDict set and get" {
     const root = @This();
 
     const pd = try PyDict(root).new();
-    defer pd.decref();
+    defer pd.obj.decref();
 
     const bar = try py.PyString.create("bar");
-    defer bar.decref();
+    defer bar.obj.decref();
     try pd.setItem("foo", bar);
 
     try testing.expect(try pd.contains("foo"));
@@ -220,7 +220,7 @@ test "PyDict from" {
     const root = @This();
 
     const pd = try PyDict(root).create(.{ .foo = 123, .bar = false });
-    defer pd.decref();
+    defer pd.obj.decref();
 
     try testing.expectEqual(@as(u32, 123), (try pd.getItem(u32, "foo")).?);
 }
@@ -232,10 +232,10 @@ test "PyDict iterator" {
     const root = @This();
 
     const pd = try PyDict(root).new();
-    defer pd.decref();
+    defer pd.obj.decref();
 
     const foo = try py.PyString.create("foo");
-    defer foo.decref();
+    defer foo.obj.decref();
 
     try pd.setItem("bar", foo);
     try pd.setItem("baz", foo);

--- a/pydust/src/types/float.zig
+++ b/pydust/src/types/float.zig
@@ -47,7 +47,7 @@ test "PyFloat" {
     defer py.finalize();
 
     const pf = try PyFloat.create(1.0);
-    defer pf.decref();
+    defer pf.obj.decref();
 
     try std.testing.expectEqual(@as(f32, 1.0), try pf.as(f32));
 }

--- a/pydust/src/types/iter.zig
+++ b/pydust/src/types/iter.zig
@@ -24,7 +24,7 @@ pub fn PyIter(comptime root: type) type {
         obj: py.PyObject,
 
         const Self = @This();
-        const from = PyObjectMixin("iterator", "PyIter", Self);
+        pub const from = PyObjectMixin("iterator", "PyIter", Self);
 
         pub fn next(self: Self, comptime T: type) !?T {
             if (ffi.PyIter_Next(self.obj.py)) |result| {
@@ -50,7 +50,7 @@ test "PyIter" {
     const root = @This();
 
     const tuple = try py.PyTuple(root).create(.{ 1, 2, 3 });
-    defer tuple.decref();
+    defer tuple.obj.decref();
 
     const iterator = try py.iter(root, tuple);
     var previous: u64 = 0;

--- a/pydust/src/types/list.zig
+++ b/pydust/src/types/list.zig
@@ -118,7 +118,7 @@ test "PyList" {
     const root = @This();
 
     var list = try PyList(root).new(2);
-    defer list.decref();
+    defer list.obj.decref();
     try list.setItem(0, 1);
     try list.setItem(1, 2.0);
 
@@ -139,7 +139,7 @@ test "PyList" {
     try testing.expectEqual(@as(i64, 1), try list.getItem(i64, 0));
 
     const tuple = try list.toTuple();
-    defer tuple.decref();
+    defer tuple.obj.decref();
 
     try std.testing.expectEqual(@as(usize, 4), tuple.length());
 }
@@ -151,7 +151,7 @@ test "PyList setOwnedItem" {
     const root = @This();
 
     var list = try PyList(root).new(2);
-    defer list.decref();
+    defer list.obj.decref();
     const py1 = try py.create(root, 1);
     defer py1.decref();
     try list.setOwnedItem(0, py1);

--- a/pydust/src/types/long.zig
+++ b/pydust/src/types/long.zig
@@ -63,13 +63,13 @@ test "PyLong" {
     defer py.finalize();
 
     const pl = try PyLong.create(100);
-    defer pl.decref();
+    defer pl.obj.decref();
 
     try std.testing.expectEqual(@as(c_long, 100), try pl.as(c_long));
     try std.testing.expectEqual(@as(c_ulong, 100), try pl.as(c_ulong));
 
     const neg_pl = try PyLong.create(@as(c_long, -100));
-    defer neg_pl.decref();
+    defer neg_pl.obj.decref();
 
     try std.testing.expectError(
         PyError.PyRaised,

--- a/pydust/src/types/memoryview.zig
+++ b/pydust/src/types/memoryview.zig
@@ -50,7 +50,7 @@ pub const PyMemoryView = extern struct {
                 var new_ptr_info = ptr_info;
                 switch (ptr_info.size) {
                     .slice => {},
-                    .One => switch (@typeInfo(ptr_info.child)) {
+                    .one => switch (@typeInfo(ptr_info.child)) {
                         .array => |info| new_ptr_info.child = info.child,
                         else => @compileError("invalid type given to PyMemoryview"),
                     },
@@ -70,7 +70,7 @@ test "from array" {
 
     const array = "static string";
     const mv = try PyMemoryView.fromSlice(array);
-    defer mv.decref();
+    defer mv.obj.decref();
 
     const root = @This();
     var buf = try mv.obj.getBuffer(root, py.PyBuffer.Flags.ANY_CONTIGUOUS);
@@ -86,7 +86,7 @@ test "from slice" {
     const slice: []const u8 = try std.testing.allocator.dupe(u8, array);
     defer std.testing.allocator.free(slice);
     const mv = try PyMemoryView.fromSlice(slice);
-    defer mv.decref();
+    defer mv.obj.decref();
 
     const root = @This();
     var buf = try mv.obj.getBuffer(root, py.PyBuffer.Flags.ANY_CONTIGUOUS);
@@ -102,7 +102,7 @@ test "from mutable slice" {
     const slice = try std.testing.allocator.alloc(u8, array.len);
     defer std.testing.allocator.free(slice);
     const mv = try PyMemoryView.fromSlice(slice);
-    defer mv.decref();
+    defer mv.obj.decref();
     @memcpy(slice, array);
 
     const root = @This();

--- a/pydust/src/types/obj.zig
+++ b/pydust/src/types/obj.zig
@@ -144,8 +144,8 @@ test "call" {
 
     const root = @This();
 
-    const math = try py.import(root, "math");
-    defer math.decref();
+    const math = try py.PyModule(root).from.checked(root, try py.import(root, "math"));
+    defer math.obj.decref();
 
     const result = try math.call(f32, "pow", .{ 2, 3 }, .{});
     try std.testing.expectEqual(@as(f32, 8.0), result);

--- a/pydust/src/types/slice.zig
+++ b/pydust/src/types/slice.zig
@@ -27,12 +27,12 @@ pub fn PySlice(comptime root: type) type {
 
         pub fn create(start: anytype, stop: anytype, step: anytype) !Self {
             // TODO(ngates): think about how to improve comptime optional handling?
-            const pystart = if (@typeInfo(@TypeOf(start)) == .Null) null else (try py.create(root, start)).py;
-            defer if (@typeInfo(@TypeOf(start)) != .Null) py.decref(root, pystart);
-            const pystop = if (@typeInfo(@TypeOf(stop)) == .Null) null else (try py.create(root, stop)).py;
-            defer if (@typeInfo(@TypeOf(stop)) != .Null) py.decref(root, pystop);
-            const pystep = if (@typeInfo(@TypeOf(step)) == .Null) null else (try py.create(root, step)).py;
-            defer if (@typeInfo(@TypeOf(step)) != .Null) py.decref(root, pystep);
+            const pystart = if (@typeInfo(@TypeOf(start)) == .null) null else (try py.create(root, start)).py;
+            defer if (@typeInfo(@TypeOf(start)) != .null) py.decref(root, pystart);
+            const pystop = if (@typeInfo(@TypeOf(stop)) == .null) null else (try py.create(root, stop)).py;
+            defer if (@typeInfo(@TypeOf(stop)) != .null) py.decref(root, pystop);
+            const pystep = if (@typeInfo(@TypeOf(step)) == .null) null else (try py.create(root, step)).py;
+            defer if (@typeInfo(@TypeOf(step)) != .null) py.decref(root, pystep);
 
             const pyslice = ffi.PySlice_New(pystart, pystop, pystep) orelse return PyError.PyRaised;
             return .{ .obj = .{ .py = pyslice } };
@@ -59,7 +59,7 @@ test "PySlice" {
     const root = @This();
 
     const range = try PySlice(root).create(0, 100, null);
-    defer range.decref();
+    defer range.obj.decref();
 
     try std.testing.expectEqual(@as(u64, 0), try range.getStart(u64));
     try std.testing.expectEqual(@as(u64, 100), try range.getStop(u64));

--- a/pydust/src/types/str.zig
+++ b/pydust/src/types/str.zig
@@ -104,7 +104,7 @@ test "PyString" {
     var ps = try PyString.create(a);
     // defer ps.decref();  <-- We don't need to decref here since append steals the reference to self.
     ps = try ps.appendSlice(b);
-    defer ps.decref();
+    defer ps.obj.decref();
 
     const ps_slice = try ps.asSlice();
 
@@ -121,7 +121,7 @@ test "PyString createFmt" {
     defer py.finalize();
 
     const a = try PyString.createFmt("Hello, {s}!", .{"foo"});
-    defer a.decref();
+    defer a.obj.decref();
 
     try testing.expectEqualStrings("Hello, foo!", try a.asSlice());
 }

--- a/pydust/src/types/tuple.zig
+++ b/pydust/src/types/tuple.zig
@@ -119,12 +119,12 @@ test "PyTuple" {
 
     const root = @This();
     const first = try PyLong.create(1);
-    defer first.decref();
+    defer first.obj.decref();
     const second = try PyFloat.create(1.0);
-    defer second.decref();
+    defer second.obj.decref();
 
     var tuple = try PyTuple(root).create(.{ first.obj, second.obj });
-    defer tuple.decref();
+    defer tuple.obj.decref();
 
     try std.testing.expectEqual(@as(usize, 2), tuple.length());
 
@@ -141,7 +141,7 @@ test "PyTuple setOwnedItem" {
 
     const root = @This();
     var tuple = try PyTuple(root).new(2);
-    defer tuple.decref();
+    defer tuple.obj.decref();
     const py1 = try py.create(root, 1);
     defer py1.decref();
     try tuple.setOwnedItem(0, py1);

--- a/pydust/src/types/type.zig
+++ b/pydust/src/types/type.zig
@@ -63,7 +63,7 @@ test "PyType" {
     const io = try py.import(root, "io");
     defer io.decref();
 
-    const StringIO = try io.getAs(py.PyType, "StringIO");
+    const StringIO = try py.PyType.from.checked(root, try io.get("StringIO"));
     try std.testing.expectEqualSlices(u8, "StringIO", try (try StringIO.name()).asSlice());
 
     const sio = try py.call0(root, py.PyObject, StringIO);


### PR DESCRIPTION
#496 made me realize that "library tests" (`zig build test`) don't run under CI.  Many of them were broken by recent PRs.  Let's restore them.

For some reason, however
```bash
$ poetry run python -m ziglang build test
test
└─ run test stderr
Exception ignored on threading shutdown:
OverflowError: can't convert negative int to unsigned
$ echo $?
0
```

Not sure whether to worry about it.